### PR TITLE
feat: update ToolDetails client and types

### DIFF
--- a/app/(private routes)/tools/[toolId]/ToolDetails.client.tsx
+++ b/app/(private routes)/tools/[toolId]/ToolDetails.client.tsx
@@ -1,15 +1,15 @@
-"use client";
+'use client';
 
-import { useState } from "react";
-import { useRouter } from "next/navigation";
-import Image from "next/image";
-import Link from "next/link";
-import { useQuery } from "@tanstack/react-query";
-import { useAuthStore } from "@/lib/store/authStore";
-import AuthRequiredModal from "@/components/AuthRequiredModal/AuthRequiredModal";
-import css from "./ToolDetailsPage.module.css";
-import { fetchToolById } from "@/lib/api/clientApi";
-import Loading from "@/app/loading";
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import Image from 'next/image';
+import Link from 'next/link';
+import { useQuery } from '@tanstack/react-query';
+import { useAuthStore } from '@/lib/store/authStore';
+import AuthRequiredModal from '@/components/AuthRequiredModal/AuthRequiredModal';
+import css from './ToolDetailsPage.module.css';
+import { fetchToolById } from '@/lib/api/clientApi';
+import Loading from '@/app/loading';
 
 interface ToolDetailsClientProps {
   toolId: string;
@@ -25,11 +25,11 @@ export default function ToolDetailsClient({ toolId }: ToolDetailsClientProps) {
     isLoading,
     error,
   } = useQuery({
-    queryKey: ["tool", toolId],
+    queryKey: ['tool', toolId],
     queryFn: () => fetchToolById(toolId),
     refetchOnMount: false,
   });
-
+  console.log('Tool data:', tool);
   const handleBookClick = () => {
     if (isAuthenticated) {
       router.push(`/tools/${toolId}/booking`);
@@ -45,7 +45,7 @@ export default function ToolDetailsClient({ toolId }: ToolDetailsClientProps) {
   if (error || !tool) {
     return (
       <section className={css.main}>
-        <div className={"container"}>
+        <div className={'container'}>
           <div className={css.error}>
             Помилка завантаження інструменту. Спробуйте пізніше.
           </div>
@@ -90,23 +90,23 @@ export default function ToolDetailsClient({ toolId }: ToolDetailsClientProps) {
               {/* Owner Information */}
               <div className={css.ownerBlock}>
                 <div className={css.ownerInfo}>
-                  {user?.avatarUrl ? (
+                  {tool.owner.avatarUrl ? (
                     <Image
-                      src={user.avatarUrl}
-                      alt={user.name}
+                      src={tool.owner.avatarUrl}
+                      alt={tool.owner.name}
                       width={80}
                       height={80}
                       className={css.ownerAvatar}
                     />
                   ) : (
                     <div className={css.ownerAvatarPlaceholder}>
-                      {user?.name.charAt(0).toUpperCase()}
+                      {tool.owner.name.charAt(0).toUpperCase()}
                     </div>
                   )}
                   <div className={css.ownerDetails}>
-                    <p className={css.ownerName}>{user?.name}</p>
+                    <p className={css.ownerName}>{tool.owner.name}</p>
                     <Link
-                      href={`/profile/${user?._id}`}
+                      href={`/profile/${tool.owner._id}`}
                       className={css.profileLink}
                     >
                       Переглянути профіль

--- a/types/tool.ts
+++ b/types/tool.ts
@@ -1,6 +1,7 @@
+import {User} from "./user";
 export interface Tool {
   _id: string;
-  owner: string;
+  owner: User;
   category: string;
   name: string;
   description: string;


### PR DESCRIPTION
я подивився в нас майже 1 в1 функції усюди там буквально просто ти пишеш id а я toolId  я вирішив нічого там не змінювати , тобто всі api твої 

я лише додав імпорт Юзер в файл types/tool , і там змінив owner:string на owner:User 
і в самому файлі  ToolDetails.client поміняв змінні щоб підхватувало аватарку юзера і його імя , і все 

в мене з моїм локальним беком працює , змержиш мій коміт на бек спочатку (я там ще виправив avatarUrl в юзер котроллері) , потім цей , і має будти тіп топ 

завтра подивлюсь ще сss 
![382f21b8-b819-4189-ae95-ccd0516417b4](https://github.com/user-attachments/assets/6d667329-8190-4b9d-b207-bd000eea5397)
